### PR TITLE
Fix interface type-hint issue

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -545,7 +545,10 @@ class Container implements ContainerInterface {
 
             if (array_key_exists($name, $ruleArgs)) {
                 $value = $ruleArgs[$name];
-            } elseif ($param->getClass() && !(isset($ruleArgs[$pos]) && is_object($ruleArgs[$pos]) && get_class($ruleArgs[$pos]) === $param->getClass()->getName())) {
+            } elseif ($param->getClass()
+                && !(isset($ruleArgs[$pos]) && is_object($ruleArgs[$pos]) && get_class($ruleArgs[$pos]) === $param->getClass()->getName())
+                && ($param->getClass()->isInstantiable() || isset($this->rules[$param->getClass()->getName()]) || array_key_exists($param->getClass()->getName(), $this->instances))
+            ) {
                 $value = new DefaultReference($this->normalizeID($param->getClass()->getName()));
             } elseif (array_key_exists($pos, $ruleArgs)) {
                 $value = $ruleArgs[$pos];

--- a/tests/ConstructorArgsTest.php
+++ b/tests/ConstructorArgsTest.php
@@ -140,4 +140,37 @@ class ConstructorArgsTest extends TestBase {
         $this->assertInstanceOf(self::DB_DECORATOR, $db);
         $this->assertSame('default', $db->db->name);
     }
+
+    /**
+     * A constructor with an interface hint should work when there is an instance for the interface.
+     */
+    public function testRulelessInterfaceHintWithInstance() {
+        $dic = new Container();
+
+        $dbInst = new Db('foo');
+        $dic->setInstance(self::DB_INTERFACE, $dbInst);
+
+        /* @var \Garden\Container\Tests\Fixtures\DbDecorator $db */
+        $db = $dic->get(self::DB_DECORATOR);
+
+        $this->assertInstanceOf(self::DB_DECORATOR, $db);
+        $this->assertSame($dbInst, $db->db);
+    }
+
+    /**
+     * A constructor with an interface hint should work when there is a rule for the interface.
+     */
+    public function testRulelessInterfaceHintWithRule() {
+        $dic = new Container();
+
+        $dic->rule(self::DB_INTERFACE)
+            ->setClass(self::DB)
+            ->setConstructorArgs(['rule']);
+
+        /* @var \Garden\Container\Tests\Fixtures\DbDecorator $db */
+        $db = $dic->get(self::DB_DECORATOR);
+
+        $this->assertInstanceOf(self::DB_DECORATOR, $db);
+        $this->assertSame('rule', $db->db->name);
+    }
 }

--- a/tests/ConstructorArgsTest.php
+++ b/tests/ConstructorArgsTest.php
@@ -127,4 +127,17 @@ class ConstructorArgsTest extends TestBase {
         $db = $dic->get(self::PDODB);
         $this->assertSame('localhost', $db->name);
     }
+
+    /**
+     * A constructor with an interface hint should not fail if there is no rule for the interface.
+     */
+    public function testRulelessInterfaceHint() {
+        $dic = new Container();
+
+        /* @var \Garden\Container\Tests\Fixtures\DbDecorator $db */
+        $db = $dic->get(self::DB_DECORATOR);
+
+        $this->assertInstanceOf(self::DB_DECORATOR, $db);
+        $this->assertSame('default', $db->db->name);
+    }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -347,4 +347,13 @@ class ContainerTest extends TestBase {
             $this->assertNotSame($db1, $db2);
         }
     }
+
+    /**
+     * The container should not have an interface.
+     */
+    public function testDoesNotHaveInterface() {
+        $dic = new Container();
+
+        $this->assertFalse($dic->has(self::DB_INTERFACE));
+    }
 }

--- a/tests/Fixtures/DbDecorator.php
+++ b/tests/Fixtures/DbDecorator.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace Garden\Container\Tests\Fixtures;
+
+
+class DbDecorator implements DbInterface {
+    /**
+     * @var DbInterface
+     */
+    public $db;
+
+    public function __construct(DbInterface $db = null) {
+        if ($db === null) {
+            $this->db = new Db('default');
+        } else {
+            $this->db = $db;
+        }
+    }
+}

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -11,6 +11,7 @@ namespace Garden\Container\Tests;
 abstract class TestBase extends \PHPUnit_Framework_TestCase {
     const DB = 'Garden\Container\Tests\Fixtures\Db';
     const DB_INTERFACE = 'Garden\Container\Tests\Fixtures\DbInterface';
+    const DB_DECORATOR = 'Garden\Container\Tests\Fixtures\DbDecorator';
     const FOO = 'Garden\Container\Tests\Fixtures\Foo';
     const FOO_AWARE = 'Garden\Container\Tests\Fixtures\FooAwareInterface';
     const PDODB = 'Garden\Container\Tests\Fixtures\PdoDb';


### PR DESCRIPTION
When an interface type hint doesn't have a rule/instance then the container shouldn't try and construct the interface.