### PR TITLE
Remove support for PHP versions older than 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
+    - 7.1
     - hhvm
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4.0",
+		"php": ">=5.6.0",
 		"container-interop/container-interop": "^1.1"
 	},
 	"autoload": {

--- a/src/Container.php
+++ b/src/Container.php
@@ -414,8 +414,8 @@ class Container implements ContainerInterface {
             if ($constructor && $constructor->getNumberOfParameters() > 0) {
                 $constructorArgs = $this->makeDefaultArgs($constructor, (array)$rule['constructorArgs'], $rule);
 
-                $factory = function ($args) use ($class, $constructorArgs) {
-                    return $class->newInstanceArgs($this->resolveArgs($constructorArgs, $args));
+                $factory = function ($args) use ($className, $constructorArgs) {
+                    return new $className(...array_values($this->resolveArgs($constructorArgs, $args)));
                 };
             } else {
                 $factory = function () use ($className) {


### PR DESCRIPTION
Since PHP 5.6 is the only 5.x version supported by PHP.net we are removing support for older versions of PHP. This allows the container to free up some memory by using language features that are available as of PHP 5.6.