### PR TITLE
Allow reference arguments to be resolved by ordinal

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -602,7 +602,13 @@ class Container implements ContainerInterface {
      * @throws MissingArgumentException Throws an exception when a required parameter is missing.
      */
     private function resolveArgs(array $defaultArgs, array $args, $instance = null) {
-        $args = array_change_key_case($args);
+        // First resolve all passed arguments so their types are known.
+        $args = array_map(
+            function ($arg) use ($instance) {
+                return $arg instanceof ReferenceInterface ? $arg->resolve($this, $instance) : $arg;
+            },
+            array_change_key_case($args)
+        );
 
         $pos = 0;
         foreach ($defaultArgs as $name => &$default) {

--- a/tests/ConstructorArgsTest.php
+++ b/tests/ConstructorArgsTest.php
@@ -221,4 +221,67 @@ class ConstructorArgsTest extends TestBase {
         $r = $dic->getArgs(FooConsumer::class, [$foo]);
         $this->assertSame($foo, $r->foo);
     }
+
+    /**
+     * I should be able to pass a required parameter by ordinal reference.
+     *
+     * @param bool $shared Shared or factory construction.
+     * @dataProvider provideShared
+     */
+    public function testOrdinalReferenceArg($shared) {
+        $dic = (new Container())->setShared($shared);
+
+        $r = $dic->getArgs(FooConsumer::class, [new Reference(Foo::class)]);
+    }
+
+    /**
+     * I should be able to set constructor arguments by ordinal reference.
+     *
+     * @param bool $shared Shared or factory construction.
+     * @dataProvider provideShared
+     */
+    public function testOrdinalConstructorReferenceArg($shared) {
+        $dic = (new Container())->setShared($shared);
+
+        $dic->rule(FooConsumer::class)
+            ->setConstructorArgs([new Reference(Foo::class)]);
+
+        $r = $dic->get(FooConsumer::class);
+    }
+
+    /**
+     * I should be able to override reference arguments by ordinal.
+     *
+     * @param bool $shared Shared or factory construction.
+     * @dataProvider provideShared
+     */
+    public function testOrdinalConstructorReferenceArgOverride($shared) {
+        $dic = (new Container())->setShared($shared);
+
+        $dic->rule(FooConsumer::class)
+            ->setConstructorArgs([new Reference(Foo::class)]);
+
+        $foo = new Foo();
+
+        $r = $dic->getArgs(FooConsumer::class, [$foo]);
+        $this->assertSame($foo, $r->foo);
+    }
+
+    /**
+     * I should be able to override reference arguments by ordinal reference.
+     *
+     * @param bool $shared Shared or factory construction.
+     * @dataProvider provideShared
+     */
+    public function testReferenceOverride($shared) {
+        $dic = (new Container())->setShared($shared);
+
+        $dic->rule(FooConsumer::class)
+            ->setConstructorArgs([new Reference(Foo::class)]);
+
+        $dic->setInstance('baz', new Foo());
+
+        $r = $dic->getArgs(FooConsumer::class, [new Reference('baz')]);
+        $this->assertSame($dic->get('baz'), $r->foo);
+    }
 }

--- a/tests/ConstructorArgsTest.php
+++ b/tests/ConstructorArgsTest.php
@@ -204,6 +204,7 @@ class ConstructorArgsTest extends TestBase {
      */
     public function testMissingRequiredParams($shared) {
         $dic = new Container();
+        $dic->setShared($shared);
 
         $m = $dic->get(FooConsumer::class);
     }
@@ -216,6 +217,7 @@ class ConstructorArgsTest extends TestBase {
      */
     public function testPassingRequiredParam($shared) {
         $dic = new Container();
+        $dic->setShared($shared);
         $foo = new Foo();
 
         $r = $dic->getArgs(FooConsumer::class, [$foo]);


### PR DESCRIPTION
Resolve all passed reference arguments before going through default arguments.