### PR TITLE
Adds support for dumping instances from the container.

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -39,10 +39,10 @@ class Container implements ContainerInterface {
     }
 
     /**
-     * Unset all instances
+     * Clear all instances
      *
      */
-    public function dumpInstances() {
+    public function clearInstances() {
         $this->instances = [];
     }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -39,6 +39,14 @@ class Container implements ContainerInterface {
     }
 
     /**
+     * Unset all instances
+     *
+     */
+    public function dumpInstances() {
+        $this->instances = [];
+    }
+
+    /**
      * Deep clone an array.
      *
      * @param array $array The array to clone.
@@ -709,6 +717,19 @@ class Container implements ContainerInterface {
     public function hasRule($id) {
         $id = $this->normalizeID($id);
         return !empty($this->rules[$id]);
+    }
+
+    /**
+     * Returns true if the container already has an instance for the given identifier. Returns false otherwise.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return bool
+     */
+    public function hasInstance($id) {
+        $id = $this->normalizeID($id);
+
+        return isset($this->instances[$id]);
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -395,11 +395,11 @@ class ContainerTest extends TestBase {
     /**
      * Test dumping container instances.
      */
-    public function testDumping() {
+    public function testClearing() {
         $dic = new Container();
         $dic->get(self::DB);
 
-        $dic->dumpInstances();
+        $dic->clearInstances();
         $this->assertFalse($dic->hasInstance(self::DB));
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -391,4 +391,15 @@ class ContainerTest extends TestBase {
         $this->assertNotSame($db1, $db2);
         $this->assertNotSame('foo', $db1->name);
     }
+
+    /**
+     * Test dumping container instances.
+     */
+    public function testDumping() {
+        $dic = new Container();
+        $dic->get(self::DB);
+
+        $dic->dumpInstances();
+        $this->assertFalse($dic->hasInstance(self::DB));
+    }
 }


### PR DESCRIPTION
Sometimes you want to forget about all instances.