### PR TITLE
Allow the factory to be cleared add default arg value for optional parameters

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -226,10 +226,10 @@ class Container implements ContainerInterface {
     /**
      * Set the factory that will be used to create the instance for the current rule.
      *
-     * @param callable $factory This callback will be called to create the instance for the rule.
+     * @param callable|null $factory This callback will be called to create the instance for the rule.
      * @return $this
      */
-    public function setFactory(callable $factory) {
+    public function setFactory(callable $factory = null) {
         $this->currentRule['factory'] = $factory;
         return $this;
     }
@@ -622,6 +622,8 @@ class Container implements ContainerInterface {
                 $pos++;
             } elseif ($param->isDefaultValueAvailable()) {
                 $value = $param->getDefaultValue();
+            } elseif ($param->isOptional()) {
+                $value = null;
             } else {
                 $value = new RequiredParameter($param);
             }


### PR DESCRIPTION
- Build in classes or classes from extensions can have optional parameters with no default value. In this case they are set to null.
- Since base/child class rules are merged there can be a case where the base class has a factory, but the child class does not want one. Now factories can be cleared by setting them to null.