### PR TITLE
Update PHP version and add support for default values of non-existant classes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,17 @@
 language: php
 
 php:
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
-    - hhvm
+    - 7.3
 
 sudo: false
 
 matrix:
-    allow_failures:
-        - php: hhvm
     fast_finish: true
 
 install:
     - composer install
-    - composer require phpunit/phpunit ~5
 
 script: ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
 

--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,29 @@
 {
-	"name": "vanilla/garden-container",
-	"description": "A dependency injection container.",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Todd Burry",
-			"email": "todd@vanillaforums.com"
-		}
-	],
-	"require": {
-		"php": ">=5.6.0",
-		"psr/container": "^1.0"
-	},
-	"autoload": {
-		"psr-4": {
-			"Garden\\Container\\": "src"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Garden\\Container\\Tests\\": "tests"
-		}
-	}
+    "name": "vanilla/garden-container",
+    "description": "A dependency injection container.",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Todd Burry",
+            "email": "todd@vanillaforums.com"
+        }
+    ],
+    "require": {
+        "php": ">=7.1.0",
+        "psr/container": "^1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.0",
+        "ext-xdebug": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Garden\\Container\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Garden\\Container\\Tests\\": "tests"
+        }
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="false"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
         >
     <php>

--- a/src/Container.php
+++ b/src/Container.php
@@ -430,7 +430,7 @@ class Container implements ContainerInterface {
             $function = $this->reflectCallback($callback);
 
             if ($function->getNumberOfParameters() > 0) {
-                $callbackArgs = $this->makeDefaultArgs($function, (array)$rule['constructorArgs'], $rule);
+                $callbackArgs = $this->makeDefaultArgs($function, (array)$rule['constructorArgs']);
                 $factory = function ($args) use ($callback, $callbackArgs) {
                     return call_user_func_array($callback, $this->resolveArgs($callbackArgs, $args));
                 };
@@ -451,7 +451,7 @@ class Container implements ContainerInterface {
             $constructor = $class->getConstructor();
 
             if ($constructor && $constructor->getNumberOfParameters() > 0) {
-                $constructorArgs = $this->makeDefaultArgs($constructor, (array)$rule['constructorArgs'], $rule);
+                $constructorArgs = $this->makeDefaultArgs($constructor, (array)$rule['constructorArgs']);
 
                 $factory = function ($args) use ($className, $constructorArgs) {
                     return new $className(...array_values($this->resolveArgs($constructorArgs, $args)));
@@ -471,7 +471,7 @@ class Container implements ContainerInterface {
             foreach ($rule['calls'] as $call) {
                 list($methodName, $args) = $call;
                 $method = $class->getMethod($methodName);
-                $calls[] = [$methodName, $this->makeDefaultArgs($method, $args, $rule)];
+                $calls[] = [$methodName, $this->makeDefaultArgs($method, $args)];
             }
 
             // Wrap the factory in one that makes the calls.
@@ -511,7 +511,7 @@ class Container implements ContainerInterface {
 
             if ($function->getNumberOfParameters() > 0) {
                 $callbackArgs = $this->resolveArgs(
-                    $this->makeDefaultArgs($function, (array)$rule['constructorArgs'], $rule),
+                    $this->makeDefaultArgs($function, (array)$rule['constructorArgs']),
                     $args
                 );
 
@@ -592,11 +592,10 @@ class Container implements ContainerInterface {
      *
      * @param \ReflectionFunctionAbstract $function The function to make the arguments for.
      * @param array $ruleArgs An array of default arguments specifically for the function.
-     * @param array $rule The entire rule.
      * @return array Returns an array in the form `name => defaultValue`.
      * @throws NotFoundException If a non-optional class param is reflected and does not exist.
      */
-    private function makeDefaultArgs(\ReflectionFunctionAbstract $function, array $ruleArgs, array $rule = []) {
+    private function makeDefaultArgs(\ReflectionFunctionAbstract $function, array $ruleArgs) {
         $ruleArgs = array_change_key_case($ruleArgs);
         $result = [];
 

--- a/tests/AbstractContainerTest.php
+++ b/tests/AbstractContainerTest.php
@@ -8,7 +8,9 @@
 namespace Garden\Container\Tests;
 
 
-abstract class AbstractContainerTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractContainerTest extends TestCase {
     const DB = 'Garden\Container\Tests\Fixtures\Db';
     const DB_INTERFACE = 'Garden\Container\Tests\Fixtures\DbInterface';
     const DB_DECORATOR = 'Garden\Container\Tests\Fixtures\DbDecorator';

--- a/tests/ConstructorArgsTest.php
+++ b/tests/ConstructorArgsTest.php
@@ -13,6 +13,7 @@ use Garden\Container\Reference;
 use Garden\Container\Tests\Fixtures\Db;
 use Garden\Container\Tests\Fixtures\Foo;
 use Garden\Container\Tests\Fixtures\FooConsumer;
+use Garden\Container\Tests\Fixtures\OptionalConsumer;
 use Psr\Container\ContainerExceptionInterface;
 
 class ConstructorArgsTest extends AbstractContainerTest {
@@ -207,6 +208,20 @@ class ConstructorArgsTest extends AbstractContainerTest {
         $dic->setShared($shared);
 
         $m = $dic->get(FooConsumer::class);
+    }
+
+    /**
+     * Missing constructor parameters for optional values should use the optional value.
+     *
+     * @param bool $shared Shared or factory construction.
+     * @dataProvider provideShared
+     */
+    public function testMissingOptionalParams($shared) {
+        $dic = new Container();
+        $dic->setShared($shared);
+
+        $m = $dic->get(OptionalConsumer::class);
+        $this->assertInstanceOf(OptionalConsumer::class, $m);
     }
 
     /**

--- a/tests/ConstructorArgsTest.php
+++ b/tests/ConstructorArgsTest.php
@@ -9,11 +9,13 @@ namespace Garden\Container\Tests;
 
 
 use Garden\Container\Container;
+use Garden\Container\NotFoundException;
 use Garden\Container\Reference;
 use Garden\Container\Tests\Fixtures\Db;
 use Garden\Container\Tests\Fixtures\Foo;
 use Garden\Container\Tests\Fixtures\FooConsumer;
-use Garden\Container\Tests\Fixtures\OptionalConsumer;
+use Garden\Container\Tests\Fixtures\NotFoundOptionalConsumer;
+use Garden\Container\Tests\Fixtures\NotFoundRequiredConsumer;
 use Psr\Container\ContainerExceptionInterface;
 
 class ConstructorArgsTest extends AbstractContainerTest {
@@ -211,18 +213,34 @@ class ConstructorArgsTest extends AbstractContainerTest {
     }
 
     /**
-     * Missing constructor parameters for optional values should use the optional value.
+     * A required parameter that could not be found (non-existant class) should throw an exception.
+     *
+     * @param bool $shared Shared or factory construction.
+     * @expectedException \Garden\Container\NotFoundException
+     * @dataProvider provideShared
+     */
+    public function testNotFoundRequiredParams($shared) {
+        $dic = new Container();
+        $dic->setShared($shared);
+
+        /** @var NotFoundOptionalConsumer $m */
+        $m = $dic->get(NotFoundRequiredConsumer::class);
+    }
+
+
+    /**
+     * An optional parameter that could not be found (non-existant class) should use the defaults.
      *
      * @param bool $shared Shared or factory construction.
      * @dataProvider provideShared
      */
-    public function testMissingOptionalParams($shared) {
+    public function testNotFoundOptionalParams($shared) {
         $dic = new Container();
         $dic->setShared($shared);
 
-        /** @var OptionalConsumer $m */
-        $m = $dic->get(OptionalConsumer::class);
-        $this->assertInstanceOf(OptionalConsumer::class, $m);
+        /** @var NotFoundOptionalConsumer $m */
+        $m = $dic->get(NotFoundOptionalConsumer::class);
+        $this->assertInstanceOf(NotFoundOptionalConsumer::class, $m);
 
         // These are the default constructor args.
         $this->assertFalse($m->configValue);

--- a/tests/ConstructorArgsTest.php
+++ b/tests/ConstructorArgsTest.php
@@ -220,8 +220,13 @@ class ConstructorArgsTest extends AbstractContainerTest {
         $dic = new Container();
         $dic->setShared($shared);
 
+        /** @var OptionalConsumer $m */
         $m = $dic->get(OptionalConsumer::class);
         $this->assertInstanceOf(OptionalConsumer::class, $m);
+
+        // These are the default constructor args.
+        $this->assertFalse($m->configValue);
+        $this->assertNull($m->foo);
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -408,9 +408,10 @@ class ContainerTest extends AbstractContainerTest {
      */
     public function testNullArgsBug() {
         $dic = new Container();
-
         $sql = new Sql();
 
         $dic->call([$sql, 'setDb'], []);
+        // Assert that no exception were thrown.
+        $this->assertTrue(true);
     }
 }

--- a/tests/Fixtures/NotFoundOptionalConsumer.php
+++ b/tests/Fixtures/NotFoundOptionalConsumer.php
@@ -8,7 +8,7 @@
 namespace Garden\Container\Tests\Fixtures;
 
 
-class OptionalConsumer {
+class NotFoundOptionalConsumer {
     public $foo;
     public $configValue;
 

--- a/tests/Fixtures/NotFoundRequiredConsumer.php
+++ b/tests/Fixtures/NotFoundRequiredConsumer.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Container\Tests\Fixtures;
+
+
+class NotFoundRequiredConsumer {
+    public $foo;
+    public $configValue;
+
+    public function __construct(SomeNonExistantInterface $foo, $configValue) {
+        $this->foo = $foo;
+        $this->configValue = $configValue;
+    }
+}

--- a/tests/Fixtures/OptionalConsumer.php
+++ b/tests/Fixtures/OptionalConsumer.php
@@ -10,8 +10,10 @@ namespace Garden\Container\Tests\Fixtures;
 
 class OptionalConsumer {
     public $foo;
+    public $configValue;
 
     public function __construct(SomeNonExistantInterface $foo = null, $configValue = false) {
         $this->foo = $foo;
+        $this->configValue = $configValue;
     }
 }

--- a/tests/Fixtures/OptionalConsumer.php
+++ b/tests/Fixtures/OptionalConsumer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Container\Tests\Fixtures;
+
+
+class OptionalConsumer {
+    public $foo;
+
+    public function __construct(SomeNonExistantInterface $foo = null, $configValue = false) {
+        $this->foo = $foo;
+    }
+}

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -44,6 +44,7 @@ class ReferenceTest extends AbstractContainerTest {
         $dic = (new Container())->setShared($shared);
 
         $r = $dic->getArgs(FooConsumer::class, [new Reference(Foo::class)]);
+        $this->assertInstanceOf(FooConsumer::class, $r);
     }
 
     /**

--- a/tests/RuleAccessTest.php
+++ b/tests/RuleAccessTest.php
@@ -204,6 +204,9 @@ class RuleAccessTest extends AbstractContainerTest {
 
         $dic->rule('foo')
             ->setAliasOf('foo');
+
+        // AbstractContainerTest has custom error assertions that aren't actually assertions.
+        $this->assertTrue(true);
     }
 
     /**


### PR DESCRIPTION
_**Warning: SemVer major changes ahead.**_

## PHP Version Upgrades

Closes https://github.com/vanilla/garden-container/issues/30

Our minimum version in Vanilla is now 7.1, so I've

- Removed PHP 5.6 & 7.0 support.
- Removed HHVM support (It's diverging).
- Added PHP 7.3 to the test matrix.

## Fixed PHPUnit dependency

I've added PHPUnit 7 as a composer dependency and make a couple changes to compensate for the new version. Previously it was not specified as a dev dependency.

The main changes that needed to be made was changing out the base class on the abstract test and making sure that every test made an assertion.

## Allow default values when a class doesn't exist.

Fixes https://github.com/vanilla/garden-container/issues/29

I've also added a test case for it.

## Unused arg removal

I've removed an unused default arg in the `Container::makeDefaultArgs` method.