### PR TITLE
Fix `addCall` ordinal reference bug

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -628,13 +628,13 @@ class Container implements ContainerInterface {
             ) {
                 $value = $ruleArgs[$pos];
                 $pos++;
+            } elseif (array_key_exists($pos, $ruleArgs)) {
+                $value = $ruleArgs[$pos];
+                $pos++;
             } elseif ($reflectedClass
                 && ($reflectedClass->isInstantiable() || isset($this->rules[$reflectedClass->name]) || array_key_exists($reflectedClass->name, $this->instances))
             ) {
                 $value = new DefaultReference($this->normalizeID($reflectedClass->name));
-            } elseif (array_key_exists($pos, $ruleArgs)) {
-                $value = $ruleArgs[$pos];
-                $pos++;
             } elseif ($param->isDefaultValueAvailable()) {
                 $value = $param->getDefaultValue();
             } elseif ($param->isOptional()) {

--- a/src/Container.php
+++ b/src/Container.php
@@ -641,7 +641,7 @@ class Container implements ContainerInterface {
                     );
                 } elseif (is_object($ordinalRule)) {
                     // The argument is an instance that matches the type hint.
-                    $isMatchingOrdinalInstance = is_a($ordinalRule, $reflectedClass->name);
+                    $isMatchingOrdinalInstance = is_a($ordinalRule, $reflectedClass->getName());
                 }
             }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -469,7 +469,7 @@ class Container implements ContainerInterface {
 
             // Generate the calls array.
             foreach ($rule['calls'] as $call) {
-                list($methodName, $args) = $call;
+                [$methodName, $args] = $call;
                 $method = $class->getMethod($methodName);
                 $calls[] = [$methodName, $this->makeDefaultArgs($method, $args)];
             }
@@ -479,9 +479,11 @@ class Container implements ContainerInterface {
                 $instance = $factory($args);
 
                 foreach ($calls as $call) {
+                    [$methodName, $defaultArgs] = $call;
+                    $finalArgs = $this->resolveArgs($defaultArgs, [], $instance);
                     call_user_func_array(
-                        [$instance, $call[0]],
-                        $this->resolveArgs($call[1], [], $instance)
+                        [$instance, $methodName],
+                        $finalArgs
                     );
                 }
 
@@ -618,23 +620,47 @@ class Container implements ContainerInterface {
                 }
             }
 
+            $hasOrdinalRule = isset($ruleArgs[$pos]);
+
+            $isMatchingOrdinalReference = false;
+            $isMatchingOrdinalInstance = false;
+            if ($hasOrdinalRule && $reflectedClass) {
+                $ordinalRule = $ruleArgs[$pos];
+
+                if ($ordinalRule instanceof Reference) {
+                    $ruleClass = $ordinalRule->getName();
+                    if (($resolvedRuleClass = $this->findRuleClass($ruleClass)) !== null) {
+                        $ruleClass = $resolvedRuleClass;
+                    }
+
+                    // The argument is a reference that matches the type hint.
+                    $isMatchingOrdinalReference = is_a(
+                        $ruleClass,
+                        $reflectedClass->getName(),
+                        true
+                    );
+                } elseif (is_object($ordinalRule)) {
+                    // The argument is an instance that matches the type hint.
+                    $isMatchingOrdinalInstance = is_a($ordinalRule, $reflectedClass->name);
+                }
+            }
+
             if (array_key_exists($name, $ruleArgs)) {
                 $value = $ruleArgs[$name];
-            } elseif ($reflectedClass && isset($ruleArgs[$pos]) &&
-                // The argument is a reference that matches the type hint.
-                (($ruleArgs[$pos] instanceof Reference && is_a($this->findRuleClass($ruleArgs[$pos]->getName()), $reflectedClass->getName(), true)) ||
-                // The argument is an instance that matches the type hint.
-                (is_object($ruleArgs[$pos]) && is_a($ruleArgs[$pos], $reflectedClass->name)))
+            } elseif (
+                $reflectedClass
+                && $hasOrdinalRule
+                && ($isMatchingOrdinalReference|| $isMatchingOrdinalInstance)
             ) {
-                $value = $ruleArgs[$pos];
-                $pos++;
-            } elseif (array_key_exists($pos, $ruleArgs)) {
                 $value = $ruleArgs[$pos];
                 $pos++;
             } elseif ($reflectedClass
                 && ($reflectedClass->isInstantiable() || isset($this->rules[$reflectedClass->name]) || array_key_exists($reflectedClass->name, $this->instances))
             ) {
                 $value = new DefaultReference($this->normalizeID($reflectedClass->name));
+            } elseif ($hasOrdinalRule) {
+                $value = $ruleArgs[$pos];
+                $pos++;
             } elseif ($param->isDefaultValueAvailable()) {
                 $value = $param->getDefaultValue();
             } elseif ($param->isOptional()) {

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -14,4 +14,8 @@ class Model {
     public function __construct(Sql $sql) {
         $this->sql = $sql;
     }
+
+    public function setSql(Sql $sql) {
+        $this->sql = $sql;
+    }
 }

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -27,7 +27,7 @@ class ReferenceTest extends AbstractContainerTest {
         $dic = new Container();
 
         $dic->rule(Model::class)
-            ->setConstructorArgs(['sql' => new Reference(Sql::class, ['baz'])]);
+            ->setConstructorArgs(['sql' => $this->makeBazSql()]);
 
         /* @var Model $model */
         $model = $dic->get(Model::class);
@@ -107,5 +107,51 @@ class ReferenceTest extends AbstractContainerTest {
 
         $r = $dic->getArgs(FooConsumer::class, [new Reference('baz')]);
         $this->assertSame($dic->get('baz'), $r->foo);
+    }
+
+    /**
+     * Make a sql reference with name 'not-baz'.
+     */
+    private function makeNotBazSql(): Reference {
+        return new Reference(Sql::class, ['not-baz']);
+    }
+
+    /**
+     * Make a sql reference with name 'baz'.
+     */
+    private function makeBazSql(): Reference {
+        return new Reference(Sql::class, ['baz']);
+    }
+
+    /**
+     * References can be passed as a named argument in an `addCall()` rule.
+     */
+    public function testReferencePassAsCallArgument() {
+        $dic = new Container();
+
+        $dic->rule(Model::class)
+            ->setConstructorArgs(['sql' => $this->makeNotBazSql()])
+            ->addCall('setSql', ['sql' => $this->makeBazSql()]);
+        ;
+
+        /* @var Model $model */
+        $model = $dic->get(Model::class);
+        $this->assertSame('baz', $model->sql->name);
+    }
+
+    /**
+     * References can be passed to as ordinal argument in an `addCall()` rule.
+     */
+    public function testReferencePassAsOrdinalCallArgument() {
+        $dic = new Container();
+
+        $dic->rule(Model::class)
+            ->setConstructorArgs(['sql' => $this->makeNotBazSql()])
+            ->addCall('setSql', [$this->makeBazSql()])
+        ;
+
+        /* @var Model $model */
+        $model = $dic->get(Model::class);
+        $this->assertSame('baz', $model->sql->name);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/garden-container/issues/35

https://github.com/vanilla/garden-container/commit/0b871e8ae1692f87ea59ca637aac245b16f93835 adds unit tests to demonstrate a bug in ordinal arguments with `addCall`. `testReferencePassAsCallArgument()` passed but `testReferencePassAsOrdinalCallArgument()` did not.

The actual issue was that `$isMatchingOrdinalReference` would only be true if we had a container rule configured for the reference. It did not match the default behaviour of a container lookup.

Finally resolution of this involved cleaning up `makeDefaultArgs()` to be a bit easier to debug/look at.

Then altering the resolved rule class to be just the reference class if a rule in the container is not found.