### PR TITLE
Fix rule inheritance through class extension

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -369,7 +369,7 @@ class Container implements ContainerInterface {
             for ($class = get_parent_class($nid); !empty($class); $class = get_parent_class($class)) {
                 // Don't add the rule if it doesn't say to inherit.
                 if (!isset($this->rules[$class]) || (isset($this->rules[$class]['inherit']) && !$this->rules[$class]['inherit'])) {
-                    break;
+                    continue;
                 }
                 $rule += $this->rules[$class];
             }

--- a/tests/ConstructorArgsTest.php
+++ b/tests/ConstructorArgsTest.php
@@ -12,6 +12,7 @@ use Garden\Container\Container;
 use Garden\Container\NotFoundException;
 use Garden\Container\Reference;
 use Garden\Container\Tests\Fixtures\Db;
+use Garden\Container\Tests\Fixtures\ExtendedPdoDb;
 use Garden\Container\Tests\Fixtures\Foo;
 use Garden\Container\Tests\Fixtures\FooConsumer;
 use Garden\Container\Tests\Fixtures\NotFoundOptionalConsumer;
@@ -61,6 +62,45 @@ class ConstructorArgsTest extends AbstractContainerTest {
         /** @var Db $db */
         $db = $c->get(self::PDODB);
         $this->assertNotSame('foo', $db->name);
+    }
+
+    /**
+     * Make sure inherit rules are checked through implmenting interfaces.
+     */
+    public function testDeepInheritRulesThroughInterface() {
+        $c = new Container();
+
+        $c
+            ->rule(self::DB)
+            ->setInherit(true)
+            ->setConstructorArgs(['db'])
+            ->rule(self::PDODB)
+            ->setInherit(false)
+            ->setConstructorArgs(['pdodb']);
+
+        /** @var Db $db */
+        $db = $c->get(ExtendedPdoDb::class);
+        $this->assertSame('db', $db->name);
+    }
+
+
+    /**
+     * Make sure inherit rules are checked through inherited classes.
+     */
+    public function testDeepInheritRulesThroughClass() {
+        $c = new Container();
+
+        $c
+            ->rule(self::DB_INTERFACE)
+            ->setInherit(true)
+            ->setConstructorArgs(['interface'])
+            ->rule(self::DB)
+            ->setInherit(false)
+            ->setConstructorArgs(['db']);
+
+        /** @var Db $db */
+        $db = $c->get(self::PDODB);
+        $this->assertSame('interface', $db->name);
     }
 
     /**

--- a/tests/Fixtures/ExtendedPdoDb.php
+++ b/tests/Fixtures/ExtendedPdoDb.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @author Adam Charron <adam@charrondev.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Container\Tests\Fixtures;
+
+
+class ExtendedPdoDb extends PdoDb {
+
+}


### PR DESCRIPTION
In this PR I've added tests for, and fixed https://github.com/vanilla/garden-container/issues/36

`testDeepInheritRulesThroughInterface()` was passing before the fix, but `testDeepInheritRulesThroughClass()` was failing.