### PR TITLE
Update the container to clear a factory cache when new rules are added

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -319,6 +319,11 @@ class Container implements ContainerInterface {
     public function addCall($method, array $args = []) {
         $this->currentRule['calls'][] = [$method, $args];
 
+        // Something added a rule. If we have any existing factories make sure we clear them.
+        if (isset($this->factories[$this->currentRuleName])) {
+            unset($this->factories[$this->currentRuleName]);
+        }
+
         return $this;
     }
 

--- a/tests/RuleFactoryTest.php
+++ b/tests/RuleFactoryTest.php
@@ -8,6 +8,7 @@
 namespace Garden\Container\Tests;
 use Garden\Container\Container;
 use Garden\Container\Tests\Fixtures\Db;
+use Garden\Container\Tests\Fixtures\Foo;
 
 /**
  * Tests for the container's rule factories.
@@ -144,5 +145,30 @@ class RuleFactoryTest extends AbstractContainerTest {
         $foo = $dic->get(self::FOO);
         $this->assertSame('foo', $foo->foo);
         $this->assertSame('bar', $foo->bar);
+    }
+
+    /**
+     * Test that the a factory cache is cleared after a rule change.
+     */
+    public function testCacheClearOnRule() {
+        $dic = new Container();
+
+        $dic
+            ->rule(Foo::class)
+            ->setShared(false)
+            ->addCall('setFoo', ['foo1'])
+            ->addCall('setFoo', ['foo2'])
+        ;
+
+        /** @var Foo $foo */
+        $foo = $dic->get(Foo::class);
+        $this->assertEquals('foo2', $foo->foo);
+
+        $dic->rule(Foo::class)
+            ->addCall('setFoo', ['foo3']);
+
+        /** @var Foo $foo */
+        $foo = $dic->get(Foo::class);
+        $this->assertEquals('foo3', $foo->foo);
     }
 }


### PR DESCRIPTION
We had a bug where the container would silently add a new call that would never be applied because the factory was already cached.

I've updated it to clear the factory cache for a rule when a new call is added, and added a reproducing test.