### PR TITLE
Fix adding a call to an existing instance

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -262,6 +262,8 @@ class Container implements ContainerInterface, ContainerConfigurationInterface
 
     /**
      * @inheritDoc
+     *
+     * @throws ContainerException
      */
     public function addCall(string $method, array $args = [])
     {
@@ -270,6 +272,12 @@ class Container implements ContainerInterface, ContainerConfigurationInterface
         // Something added a rule. If we have any existing factories make sure we clear them.
         if (isset($this->factories[$this->currentRuleName])) {
             unset($this->factories[$this->currentRuleName]);
+        }
+
+        // If we have any existing instances make sure we add the call onto the instance.
+        if ($this->hasInstance($this->currentRuleName)) {
+            $obj = $this->get($this->currentRuleName);
+            $this->call([$obj, $method], $args);
         }
 
         return $this;

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -18,6 +18,8 @@ use Garden\Container\Tests\Fixtures\CircleA;
 use Garden\Container\Tests\Fixtures\CircleB;
 use Garden\Container\Tests\Fixtures\CircleC;
 use Garden\Container\Tests\Fixtures\Db;
+use Garden\Container\Tests\Fixtures\Foo;
+use Garden\Container\Tests\Fixtures\FooAwareInterface;
 use Garden\Container\Tests\Fixtures\Sql;
 use Garden\Container\Tests\Fixtures\Tuple;
 use Foo\NotFound;
@@ -169,6 +171,21 @@ class ContainerTest extends AbstractContainerTest
         $foo = $dic->get(self::FOO);
         $this->assertSame(123, $foo->foo);
         $this->assertSame(456, $foo->bar);
+    }
+
+    /**
+     * Test that adding a call to an existing instance works.
+     *
+     * @return void
+     */
+    public function testAddCallToExistingInstance(): void
+    {
+        $dic = new Container();
+        $dic->rule(Foo::class)->setShared(true);
+
+        $foo = $dic->get(Foo::class);
+        $dic->rule(Foo::class)->addCall("setFoo", [123]);
+        $this->assertEquals(123, $foo->foo);
     }
 
     /**


### PR DESCRIPTION
This PR adds the ability to use `addCall` if a shared instance already exists.